### PR TITLE
Improve performance for DbalQueryExtractor

### DIFF
--- a/src/Flow/ETL/Adapter/Doctrine/DbalQueryExtractor.php
+++ b/src/Flow/ETL/Adapter/Doctrine/DbalQueryExtractor.php
@@ -64,14 +64,14 @@ final class DbalQueryExtractor implements Extractor
     public function extract() : \Generator
     {
         foreach ($this->parametersSet->all() as $parameters) {
-            $rows = new Rows();
+            $rows = [];
 
             /** @psalm-suppress ImpureMethodCall */
             foreach ($this->connection->fetchAllAssociative($this->query, $parameters, $this->types) as $row) {
-                $rows = $rows->add(Row::create(new Row\Entry\ArrayEntry($this->rowEntryName, $row)));
+                $rows[] = Row::create(new Row\Entry\ArrayEntry($this->rowEntryName, $row));
             }
 
-            yield $rows;
+            yield new Rows(...$rows);
         }
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
<li>Build Rows object on the end of foreach loop</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

**before**: https://blackfire.io/profiles/54f7aca0-0c74-4d17-8399-0843569309f3/graph
<img width="523" alt="Screenshot 2022-02-07 at 13 24 16" src="https://user-images.githubusercontent.com/7013293/152787602-63bd5fe7-abb2-4eb4-a1d5-85135814c6a8.png">

**after**: https://blackfire.io/profiles/95c3facd-e262-496d-9ab5-8e9a75bc40b5/graph
<img width="470" alt="Screenshot 2022-02-07 at 13 18 37" src="https://user-images.githubusercontent.com/7013293/152787584-3462aa9b-2f58-4a06-bc64-b01b6168746f.png">

The source of data for both profiles was table with ~166 000 rows. 

`Rows:add` method should not be used in foreach loops. In that case we iterate over 166 000 elements. Below you can find how `Rows:add` method looks like:

```php
public function add(Row ...$rows) : self
    {
        return new self(
            ...\array_merge($this->rows, $rows)
        );
    }
```

Another performance optimization would be to use:
```php
public function add(Row ...$rows) : self
    {
        return new self(...$this->rows, ...$rows);
    }
```

This is almost 2 times faster than `array_merge`: https://blackfire.io/profiles/e2deee03-c793-4785-8008-68de8373affa/graph
<img width="572" alt="Screenshot 2022-02-07 at 13 37 42" src="https://user-images.githubusercontent.com/7013293/152789439-ae40cb0c-4bfb-4936-8d4b-a7c077220916.png">

but still the best way is to not use `Rows:add` in `DbalQueryExtractor`. I'll create a PR to https://github.com/flow-php/etl with this small optimisation. 
