### PR TITLE
Fix ordering by multiple columns in DbalLimitOffsetExtractor

### DIFF
--- a/src/Flow/ETL/Adapter/Doctrine/DbalLimitOffsetExtractor.php
+++ b/src/Flow/ETL/Adapter/Doctrine/DbalLimitOffsetExtractor.php
@@ -44,7 +44,7 @@ final class DbalLimitOffsetExtractor implements Extractor
             ->from($table->name);
 
         foreach ($orderBy as $order) {
-            $queryBuilder = $queryBuilder->orderBy($order->column, $order->order->name);
+            $queryBuilder = $queryBuilder->addOrderBy($order->column, $order->order->name);
         }
 
         return new self(


### PR DESCRIPTION
Currently `DbalLimitOffsetExtractor` only orders by the last given column instead of in order of all the given ordering columns.